### PR TITLE
Filter out multiple enemy messages moving to the same location

### DIFF
--- a/WinningAndLosing/gauntlet/src/systems/mod.rs
+++ b/WinningAndLosing/gauntlet/src/systems/mod.rs
@@ -7,6 +7,7 @@ mod random_move;
 mod chasing;
 mod end_turn;
 mod movement;
+mod movement_filter;
 mod hud;
 mod tooltips;
 mod combat;
@@ -41,6 +42,8 @@ pub fn build_monster_scheduler() -> Schedule {
         .add_system(chasing::chasing_system())
         .flush()
         .add_system(combat::combat_system())
+        .flush()
+        .add_system(movement_filter::movement_filter_system())
         .flush()
         .add_system(movement::movement_system())
         .flush()

--- a/WinningAndLosing/gauntlet/src/systems/movement_filter.rs
+++ b/WinningAndLosing/gauntlet/src/systems/movement_filter.rs
@@ -1,0 +1,20 @@
+use crate::prelude::*;
+
+#[system]
+#[read_component(WantsToMove)]
+pub fn movement_filter(
+    ecs: &mut SubWorld,
+    commands: &mut CommandBuffer) {
+
+    let mut moves = <(Entity, &WantsToMove)>::query();
+    let mut pos_seen: Vec<Point> = Vec::new();
+
+    moves.iter(ecs).for_each(|(entity, want_move)| {
+        if pos_seen.contains(&want_move.destination) {
+            commands.remove(*entity);
+        }
+        else {
+            pos_seen.push(want_move.destination);
+        }
+    });
+}


### PR DESCRIPTION
This pull request is in regards to the code in Chapter 9: Victory and Defeat. At least, it's where I discovered it.

This fixes an issue with enemies being able to move into the same location at the same time.  If you have two enemies like this:
```
.g.
g..
...
```
And manipulate them into moving into the center position, they'll both end up occupying the same space.  There's no actual check at the time of processing the message that the space is free.  I think Legion's parallelism is getting in the way but I'm not sure*.

Also would like to know if I wrote this correctly or if there is a better/more efficient way.  Creating that Vec and throwing it away every frame for positions seen seems wasteful but I'm just getting started with rust so maybe not?

*I tried following your very recent [article](https://hands-on-rust.com/2021/11/06/run-your-rust-games-in-a-browser-hands-on-rust-bonus-content/) to disable Legion's parallelism and test without this fix, but it still occurs.  I still see the program using multiple threads on my computer though so I don't trust that it's actually disabled.